### PR TITLE
Update io.typoro.Typora.json

### DIFF
--- a/io.typora.Typora.json
+++ b/io.typora.Typora.json
@@ -51,7 +51,7 @@
           "type": "script",
           "dest-filename": "typora",
           "commands": [
-            "if [ ! -e $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; then",
+            "if [ ! $XDG_SESSION_TYPE = \"wayland\" ]; then",
             "exec zypak-wrapper /app/typora/Typora \"$@\"",
             "else",
             "exec zypak-wrapper /app/typora/Typora --enable-features=UseOzonePlatform -ozone-platform=wayland \"$@\"",

--- a/io.typora.Typora.json
+++ b/io.typora.Typora.json
@@ -14,6 +14,7 @@
     "--share=network",
     "--socket=pulseaudio",
     "--socket=x11",
+    "--socket=wayland",
     "--talk-name=com.canonical.AppMenu.Registrar"
   ],
   "modules": [
@@ -50,7 +51,11 @@
           "type": "script",
           "dest-filename": "typora",
           "commands": [
-            "exec zypak-wrapper /app/typora/Typora \"$@\""
+            "if [ ! -e $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; then",
+            "exec zypak-wrapper /app/typora/Typora \"$@\"",
+            "else",
+            "exec zypak-wrapper /app/typora/Typora --enable-features=UseOzonePlatform -ozone-platform=wayland \"$@\"",
+            "fi"
           ]
         },
         {


### PR DESCRIPTION
Made to work on wayland by:
adding `--socket=wayland`
extending "typora" script to add `--enable-features=UseOzonePlatform -ozone-platform=wayland` depending on the existence of the waylad socket at `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY`