### PR TITLE
Add aarch64 support

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64","aarch64"]
 }

--- a/io.typora.Typora.json
+++ b/io.typora.Typora.json
@@ -27,6 +27,7 @@
             "sources": [
                 {
                     "type": "archive",
+                    "only-arches": ["x86_64"],
                     "url": "https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-amd64.tar.gz",
                     "sha256": "a9c84b765991891572b4b67525c184d501cabfc751e6de054c902bbc7b41ee50",
                     "x-checker-data": {
@@ -35,6 +36,18 @@
                         "version-query": ".tag_name",
                         "url-query": ".assets[] | select(.name==\"pandoc-\" + $version + \"-linux-amd64.tar.gz\") | .browser_download_url"
                     }
+                },
+                {
+                    "type": "archive",
+                    "only-arches": ["aarch64"],
+                    "url": "https://github.com/jgm/pandoc/releases/download/3.1.6.2/pandoc-3.1.6.2-linux-arm64.tar.gz",
+                    "sha256": "7a7702428d5fb348aad4090397283bcbcc5305117bdc74b8263731bd8f200644",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/jgm/pandoc/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": ".assets[] | select(.name==\"pandoc-\" + $version + \"-linux-arm64.tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -42,7 +55,7 @@
             "name": "typora",
             "buildsystem": "simple",
             "build-commands": [
-                "mv Typora-linux-x64 ${FLATPAK_DEST}/typora",
+                "mv Typora-linux-* ${FLATPAK_DEST}/typora",
                 "install -Dm755 typora ${FLATPAK_DEST}/bin/typora",
                 "install -Dm644 ${FLATPAK_ID}.appdata.xml ${FLATPAK_DEST}/share/appdata/${FLATPAK_ID}.appdata.xml",
                 "install -Dm644 ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
@@ -51,8 +64,15 @@
             "sources": [
                 {
                     "type": "archive",
+                    "only-arches": ["x86_64"],
                     "url": "https://download.typora.io/linux/Typora-linux-x64-1.6.6.tar.gz",
                     "sha256": "0478de203fbdfa96b1a813a275c9d74632377f0af10c44984ae7b8a4e812e3ff"
+                },
+                {
+                    "type": "archive",
+                    "only-arches": ["aarch64"],
+                    "url": "https://download.typora.io/linux/Typora-linux-arm64-1.6.6.tar.gz",
+                    "sha256": "8135c003ca14860a6f1073808ad65421b0e125bccf1c297279d874db8c0c182d"
                 },
                 {
                     "type": "script",


### PR DESCRIPTION
This PR adds aarch64 support.

On Arch Linux ARM this crashes on startup for me; It does however run fine on postmarketOS, suggesting that the crash is an issue with Arch Linux ARM.

Keep in mind that you might need to append `--ozone-platform-hint=auto` to be able to run on Wayland.